### PR TITLE
create log path if not set to default

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
     state: directory
     owner: 'root'
     group: 'root'
-    mode: 0755
+    mode: '0755'
   when: "kong_log_path != kong_prefix_path + '/logs'"
 
 - name: 'Kong | Configure service init file.'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,6 +3,16 @@
 
 ---
 
+- name: 'Kong | Create log path'
+  become: yes
+  file:
+    path: '{{ kong_log_path }}'
+    state: directory
+    owner: 'root'
+    group: 'root'
+    mode: 0755
+  when: "kong_log_path != kong_prefix_path + '/logs'"
+
 - name: 'Kong | Configure service init file.'
   become: yes
   template:


### PR DESCRIPTION
First I'd like to say thank you for creating this role and making it public. So far it is doing exactly what I need it to do for managing Kong.

I want to customize the log directory for Kong so I tried using the `kong_log_path` variable as the log prefix. Noticed the `kong_log_path` directory is not being managed by your role. This pull request adds a task to create the `kong_log_path` directory if the value is something different than the default log directory.

This allow me to use that variable like below:

```
- { option: 'proxy_access_log', value: '{{ kong_log_path }}/access.log' }
- { option: 'proxy_error_log', value: '{{ kong_log_path }}/error.log' }
- { option: 'admin_access_log', value: '{{ kong_log_path }}/admin_access.log' }
- { option: 'admin_error_log', value: '{{ kong_log_path }}/admin_error.log' }
```